### PR TITLE
Fix error "undefined method `+' for nil:NilClass" for Linux

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+return unless platform?('windows')
+
 default['notepadpp']['install_dir'] = ENV['ProgramFiles'] + '\Notepad++'
 
 if node['kernel']['machine'] == 'x86_64'


### PR DESCRIPTION
A multi-platform cookbook can depends on notepadpp for all the
platforms it supports, since it is not possible to declare windows
only dependencies.

But in this case, notepadpp cookbook raises an error when platform
not Windows (eg Linux) when attributes/default.rb is used. It's
because ENV['ProgramFiles'] is Nil.

This fix adds 'return' early when platform is not Windows.